### PR TITLE
Fix notification title in terminal-notifier

### DIFF
--- a/updatebrew.sh
+++ b/updatebrew.sh
@@ -61,7 +61,7 @@ function msg {
 	elif (( $+commands[terminal-notifier] ))
 	then
 
-		terminal-notifier -message "$@" -contentImage "$IMAGE" -title "\$NAME" -subtitle "`timestamp`"
+		terminal-notifier -message "$@" -contentImage "$IMAGE" -title "$NAME" -subtitle "`timestamp`"
 
 	fi
 


### PR DESCRIPTION
When using terminal-notifier the notifications have `$NAME` instead of `updatebrew` as title.

I know I broke the rule of "DO NOT EDIT BELOW THIS LINE!", but the `$NAME` notification title was driving me crazy.